### PR TITLE
Add menu_name helper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ public function tools()
 
 ## Helpers
 
-There are two helpers built in for your blades
+There are three helpers built in for your blades
 
-* **menu_builder('slug')**.    
+* **menu_builder('slug')**.
 
 	Creates an html menu for given slug. Extra options are not required. By default tags are `ul` and `li`, and without html classes.
 
@@ -58,7 +58,15 @@ There are two helpers built in for your blades
 {!! menu_builder('main', 'parent-class', 'child-class', 'dl', 'dd') !!}
 ```
 
-* **menu_json('slug')**.   
+* **menu_name('slug')**.
+
+	Returns the name of the menu for a given slug.
+
+```php
+{{ menu_name('main') }}
+```
+
+* **menu_json('slug')**.
 
 	Returns a json with all items for given slug.
 

--- a/src/Http/helpers.php
+++ b/src/Http/helpers.php
@@ -26,6 +26,26 @@ if (!function_exists('menu_builder')) {
     }
 }
 
+if (!function_exists('menu_name')) {
+
+    /**
+     * Return menu name as a string
+     *
+     * @param   string  $slug
+     *
+     * @return  string
+     */
+    function menu_name($slug)
+    {
+        $menu = Menu::whereSlug($slug)->first();
+        if (!$menu) {
+            return '';
+        }
+
+        return $menu->name;
+    }
+}
+
 if (!function_exists('menu_json')) {
 
     /**


### PR DESCRIPTION
This pull request adds the `menu_name` helper to get the name of the menu (see issue #3).

Usage:
```php
{{ menu_name('main') }}
```